### PR TITLE
fix: add empty.s to fix compilation error

### DIFF
--- a/wit/async/async.go
+++ b/wit/async/async.go
@@ -218,22 +218,29 @@ func Yield() {
 }
 
 //go:wasmimport $root [waitable-set-new]
+//go:noescape
 func waitableSetNew() uint32
 
 //go:wasmimport $root [waitable-set-poll]
+//go:noescape
 func waitableSetPoll(waitableSet uint32, eventPayload unsafe.Pointer) uint32
 
 //go:wasmimport $root [waitable-set-drop]
+//go:noescape
 func waitableSetDrop(waitableSet uint32)
 
 //go:wasmimport $root [waitable-join]
+//go:noescape
 func waitableJoin(waitable, waitableSet uint32)
 
 //go:wasmimport $root [context-get-0]
+//go:noescape
 func contextGet() unsafe.Pointer
 
 //go:wasmimport $root [context-set-0]
+//go:noescape
 func contextSet(value unsafe.Pointer)
 
 //go:wasmimport $root [subtask-drop]
+//go:noescape
 func subtaskDrop(subtask uint32)

--- a/wit/async/empty.s
+++ b/wit/async/empty.s
@@ -1,0 +1,3 @@
+// This file exists for testing this package without WebAssembly,
+// allowing empty function bodies with a //go:wasmimport directive.
+// See https://pkg.go.dev/cmd/compile for more information.


### PR DESCRIPTION
# Description

When attempting to run unit tests whilst importing the `go.bytecodealliance.org/pkg/wit/types` package I get the following compilation error:
```sh
$ go test ./...
# go.bytecodealliance.org/pkg/wit/async
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:221:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:224:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:227:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:230:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:233:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:236:6: missing function body
.../go.bytecodealliance.org/pkg@v0.2.0/wit/async/async.go:239:6: missing function body
FAIL    <go module> [build failed]
FAIL
```

[`wit-bindgen-go`](https://github.com/bytecodealliance/go-modules/tree/main) got round this issue by including a blank `empty.s` assembly file within each of the directories which includes a Go file that uses the `//go:wasmimport` directive. See [here](https://github.com/wasmCloud/go/blob/main/component/gen/wasi/logging/logging/empty.s) for example.

This tricks the Go compile into thinking there is an assembly implementation of the function which has been declared, and so it no longer complains about the missing function body.

After adding the following changes, unit tests run successfully without build error.

## See more
- [wit-bindgen Issue](https://github.com/bytecodealliance/wit-bindgen/issues/1555)